### PR TITLE
CI Binary Builds for Boson

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,75 @@
+name: Build Boson binaries
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+    env:
+      BUILD_DIR: ./build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: Linux
+            backend: WebKitGtk
+            build_type: Release
+            container: archlinux:base-devel
+          - os: windows-latest
+            platform: Windows
+            backend: WebView2
+            build_type: Release
+            cmake-args: "-Dsaucer_package_all=ON -Dsaucer_serializer=Rflpp"
+          - os: macos-latest
+            platform: MacOs
+            backend: WebKit
+            build_type: Release
+            cmake-args: '-DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up build directory
+        run: mkdir -p ${{ env.BUILD_DIR }}
+
+      - name: 📋 Install Base Dependencies
+        shell: bash
+        if: matrix.platform == 'Linux'
+        run: "pacman --noconfirm -Syu cmake gcc git xorg-server-xvfb xorg-xwd openssh tmate"
+
+      - name: 📋 Install WebKitGtk
+        shell: bash
+        if: matrix.backend == 'WebKitGtk'
+        run: "pacman --noconfirm -Syu gtk4 libadwaita webkitgtk-6.0"
+
+      - name: Compile
+        run: |
+          cmake -B ${{ env.BUILD_DIR }} -S ./backend -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -Dsaucer_backend=${{ matrix.backend }} -Dsaucer_tests=ON -Dsaucer_examples=ON ${{ matrix.cmake-args }}
+
+      - name: Build
+        run: cmake --build ${{ env.BUILD_DIR }} --target boson --config ${{ matrix.build_type }}
+
+      - name: Run Tests
+        working-directory: ${{ env.BUILD_DIR }}
+        run: ctest --build-config ${{ matrix.build_type }}
+
+      - name: List build artifacts
+        if: matrix.platform != 'Windows'
+        run: ls -la ${{ env.BUILD_DIR }}/bin/
+      - name: List build artifacts (Only windows)
+        if: matrix.platform == 'Windows'
+        run: ls -Force ${{ env.BUILD_DIR }}/bin
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: boson-${{ matrix.os }}
+          path: ${{ env.BUILD_DIR }}/bin/

--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -20,6 +20,10 @@ else()
     set(OUTPUT_NAME "${OUTPUT_NAME}-linux")
 endif()
 
+if(APPLE)
+  set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "Build universal binary" FORCE)
+endif()
+
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
     set(OUTPUT_NAME "${OUTPUT_NAME}-amd64")
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86|^x86$")
@@ -34,8 +38,8 @@ endif()
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/bin>)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/bin>)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -47,6 +51,17 @@ include(FetchContent)
 
 set(saucer_static ON CACHE BOOL "Build a static library" FORCE)
 set(saucer_modules OFF CACHE BOOL "Disable module support" FORCE)
+
+set(ENV{GIT_TERMINAL_PROMPT} 0)
+
+FetchContent_Declare(
+    lockpp
+    GIT_REPOSITORY https://github.com/Curve/lockpp
+    GIT_TAG v3.0
+)
+FetchContent_MakeAvailable(lockpp)
+
+include_directories(${lockpp_SOURCE_DIR}/include)
 
 FetchContent_Declare(
     saucer
@@ -65,6 +80,10 @@ FetchContent_MakeAvailable(saucer-bindings)
 # --------------------------------------------------------------------------------------------------------
 
 add_library(${PROJECT_NAME} SHARED "src/boson.cpp")
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE BOSON_BUILD)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE cr::lockpp)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE saucer::saucer)
 
@@ -95,6 +114,9 @@ endif()
 # --------------------------------------------------------------------------------------------------------
 # Include directories
 # --------------------------------------------------------------------------------------------------------
+
+target_include_directories(${PROJECT_NAME} PRIVATE ${lockpp_SOURCE_DIR}/include)
+target_include_directories(saucer PRIVATE ${lockpp_SOURCE_DIR}/include)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${saucer-bindings_SOURCE_DIR}/include>)

--- a/backend/src/boson.cpp
+++ b/backend/src/boson.cpp
@@ -1,11 +1,12 @@
 #include "boson.hpp"
+#include "export.hpp"
 
 #define BOSON_STRING(value) #value
 #define BOSON_STRING_EXPAND(value) BOSON_STRING(value)
 
 extern "C"
 {
-    __declspec(dllimport) const char* boson_version()
+    BOSON_API const char* boson_version()
     {
         #ifndef BOSON_VERSION
             #define unknown-dev

--- a/backend/src/boson.hpp
+++ b/backend/src/boson.hpp
@@ -8,9 +8,7 @@ extern "C"
 {
 #endif
 
-
-BOSON_EXPORT const char* boson_version();
-
+BOSON_API const char* boson_version();
 
 #ifdef __cplusplus
 }

--- a/backend/src/export.hpp
+++ b/backend/src/export.hpp
@@ -1,14 +1,11 @@
-#ifndef EXPORT_HPP
-#define EXPORT_HPP
+#pragma once
 
-#ifndef BOSON_EXPORT
-    #ifdef SAUCER_EXPORT
-        #define BOSON_EXPORT SAUCER_EXPORT
-    #elif defined(_WIN32) || defined(_WIN64)
-        #define BOSON_EXPORT __declspec(dllimport)
-    #else
-        #define BOSON_EXPORT __attribute__((visibility("default")))
-    #endif
+#if defined(_WIN32) || defined(__CYGWIN__)
+  #ifdef BOSON_BUILD
+    #define BOSON_API __declspec(dllexport)
+  #else
+    #define BOSON_API __declspec(dllimport)
+  #endif
+#else
+  #define BOSON_API __attribute__((visibility("default")))
 #endif
-
-#endif //EXPORT_HPP


### PR DESCRIPTION
## 🔧 Binary Builds for Boson

### Summary

This PR introduces full CI support for building native binaries of the Boson library for **Linux**, **Windows**, and **macOS** using GitHub Actions.

### Key Features

- ✅ Compiles platform-specific binaries:
  - `WebKitGtk` (Linux)
  - `WebView2` (Windows)
  - `WebKit` (macOS Universal Binary)
- ✅ Uploads build artifacts to GitHub Actions (CI artifacts)

---

## 💡 Next Steps (Proposal)

To make the binaries easier to distribute and access, we propose two improvements to this workflow:

### Option 1 — Release-based distribution (recommended):
- Trigger the workflow on `release` publication (`on: release`)
- Automatically upload binaries as assets to the GitHub Release  
✅ Great for tagging and versioning  
✅ Users can download from the Releases page directly

### Option 2 — Push to a `bin/` directory in the repo:
- After successful CI build, commit binaries to `bin/{os}/` directories  
✅ Simple version control of builds  
⚠️ May clutter repo history and increase repo size